### PR TITLE
clef api return id rather than clef_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 node_modules
+sample_app.sqlite
+npm-debug.log
+.DS_STORE

--- a/app.js
+++ b/app.js
@@ -150,7 +150,7 @@ app.get('/login', function(req, res) {
           console.log(err);
       }
     } else {
-      var clefID = userInformation['clef_id'];
+      var clefID = userInformation['id'];
       var email = userInformation['email'];
       // Fetch a user given the `id` returned by Clef. If the user doesn't
       // exist, it is created with the email address and `id` returned by Clef.


### PR DESCRIPTION
Without this each user wouldn't have an attached clef id and would create a new user each time and would fail to logout.
